### PR TITLE
Update fixed-header.css

### DIFF
--- a/resources/css/fixed-header.css
+++ b/resources/css/fixed-header.css
@@ -1,22 +1,26 @@
 #nova .content {
-  padding-top: 30px;
+    padding-top: 30px;
 }
 
 .content .h-header {
-  z-index: 50;
-  position: fixed;
-  top: 0;
-  margin-top: 0;
-  width: 100%;
+    z-index: 50;
+    position: fixed;
+    top: 0;
+    margin-top: 0;
+    width: 100%;
+    padding-right: 240px;
 }
 
 .content .h-header .dropdown {
-  margin-right: 0;
-  position: fixed;
+    margin-right: 0;
+    position: fixed;
 }
 
 @media (max-width: 992px) {
-  #nova .content {
-    padding-top: 60px;
-  }
+    #nova .content {
+        padding-top: 60px;
+    }
+    .content .h-header {
+        padding-right: 40px;
+    }
 }


### PR DESCRIPTION
Hi! While everything was working flawlessly before, on the latest nova updates the user menu is being pulled off to the right of the screen. I fixed it this way but I am not sure if the problem is here, or on the responsive theme you're using as a base (or on my end, despite re-publishing nova's assets and clearing all cache, the issue persisted). If you're on the latest version and you don't see this behaviour, then please forgive me. Otherwise, maybe this helps. Thanks!